### PR TITLE
Refactored `DigitalContactEntity` to use `LocalDateTime` instead of `…

### DIFF
--- a/src/main/java/com/prx/directory/jpa/entity/DigitalContactEntity.java
+++ b/src/main/java/com/prx/directory/jpa/entity/DigitalContactEntity.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -26,11 +26,11 @@ public class DigitalContactEntity implements Serializable {
 
     @NotNull
     @Column(name = "created_date", nullable = false)
-    private Instant createdDate;
+    private LocalDateTime createdDate;
 
     @NotNull
     @Column(name = "last_update", nullable = false)
-    private Instant lastUpdate;
+    private LocalDateTime lastUpdate;
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -62,19 +62,19 @@ public class DigitalContactEntity implements Serializable {
         this.content = name;
     }
 
-    public Instant getCreatedDate() {
+    public LocalDateTime getCreatedDate() {
         return createdDate;
     }
 
-    public void setCreatedDate(Instant createdDate) {
+    public void setCreatedDate(LocalDateTime createdDate) {
         this.createdDate = createdDate;
     }
 
-    public Instant getLastUpdate() {
+    public LocalDateTime getLastUpdate() {
         return lastUpdate;
     }
 
-    public void setLastUpdate(Instant lastUpdate) {
+    public void setLastUpdate(LocalDateTime lastUpdate) {
         this.lastUpdate = lastUpdate;
     }
 

--- a/src/main/java/com/prx/directory/mapper/DigitalContactMapper.java
+++ b/src/main/java/com/prx/directory/mapper/DigitalContactMapper.java
@@ -2,12 +2,7 @@ package com.prx.directory.mapper;
 
 import com.prx.directory.api.v1.to.DigitalContactTO;
 import com.prx.directory.jpa.entity.DigitalContactEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.MapperConfig;
-import org.mapstruct.MappingConstants;
-import org.mapstruct.ReportingPolicy;
-
-import java.util.Objects;
+import org.mapstruct.*;
 
 /**
  * Mapper for converting DigitalContactEntity to DigitalContactTO.
@@ -23,22 +18,17 @@ import java.util.Objects;
         // Specifies that the mapper should fail if there are any unmapped properties.
         unmappedTargetPolicy = ReportingPolicy.IGNORE
 )
-public class DigitalContactMapper {
+public interface DigitalContactMapper {
     /**
      * Converts a DigitalContactEntity to a DigitalContactTO.
      *
      * @param entity the DigitalContactEntity
      * @return the DigitalContactTO
      */
-    public DigitalContactTO toTO(DigitalContactEntity entity) {
-        return new DigitalContactTO(
-                entity.getId(),
-                entity.getContent(),
-                Objects.nonNull(entity.getCreatedDate()) ? entity.getCreatedDate().atZone(java.time.ZoneId.systemDefault()).toLocalDateTime() : null,
-                Objects.nonNull(entity.getLastUpdate()) ? entity.getLastUpdate().atZone(java.time.ZoneId.systemDefault()).toLocalDateTime() : null,
-                Objects.nonNull(entity.getContactType()) ? entity.getContactType().getId() : null,
-                Objects.nonNull(entity.getBusiness()) ? entity.getBusiness().getId() : null
-        );
-    }
+    @Mapping(target = "lastUpdate", source = "lastUpdate")
+    @Mapping(target = "createdAt", source = "createdDate")
+    @Mapping(target = "businessId", source = "business.id")
+    @Mapping(target = "contactTypeId", source = "contactType.id")
+    DigitalContactTO toTO(DigitalContactEntity entity);
 }
 

--- a/src/test/java/com/prx/directory/api/v1/service/BusinessServiceImplTest.java
+++ b/src/test/java/com/prx/directory/api/v1/service/BusinessServiceImplTest.java
@@ -197,8 +197,21 @@ class BusinessServiceImplTest {
     void findBusinessByIdSuccessfully() {
         UUID id = UUID.randomUUID();
         BusinessEntity business = new BusinessEntity();
+        var businessTO = new BusinessTO(
+                id,
+                "Example Business",
+                "This is an example business description.",
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "user@domain.ext",
+                "user@domain.ext",
+                "user@domain.ext",
+                "domain.ext",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
 
-        when(businessRepository.findById(id)).thenReturn(Optional.of(business));
+        when(businessRepository.findBusinessWithDigitalContactsById(id)).thenReturn(Optional.of(business));
         when(businessMapper.toBusinessTO(business)).thenReturn(new BusinessTO(
                 id,
                 "Example Business",


### PR DESCRIPTION
This pull request introduces changes to improve the handling of date-time fields, refactor mapping logic, and enhance test coverage. The most significant updates include replacing `Instant` with `LocalDateTime` in the `DigitalContactEntity` class, transitioning the `DigitalContactMapper` to a MapStruct interface with annotations, and updating test logic to align with these changes.

### Date-Time Handling Updates:
* Replaced `Instant` with `LocalDateTime` for `createdDate` and `lastUpdate` fields in `DigitalContactEntity`, including corresponding getter and setter methods (`src/main/java/com/prx/directory/jpa/entity/DigitalContactEntity.java`). [[1]](diffhunk://#diff-163ea58db2cc0f6c218df20d89fe62a844d8b3d85f076f769b74c268e1c87afaL9-R9) [[2]](diffhunk://#diff-163ea58db2cc0f6c218df20d89fe62a844d8b3d85f076f769b74c268e1c87afaL29-R33) [[3]](diffhunk://#diff-163ea58db2cc0f6c218df20d89fe62a844d8b3d85f076f769b74c268e1c87afaL65-R77)

### Mapper Refactoring:
* Refactored `DigitalContactMapper` from a concrete class to an interface using MapStruct annotations for mapping logic, simplifying the conversion between `DigitalContactEntity` and `DigitalContactTO` (`src/main/java/com/prx/directory/mapper/DigitalContactMapper.java`). [[1]](diffhunk://#diff-ebaa1ec96547418aba6f2569906a22d428520afd8d22d2cd775aa00dcd024b95L5-R5) [[2]](diffhunk://#diff-ebaa1ec96547418aba6f2569906a22d428520afd8d22d2cd775aa00dcd024b95L26-R32)

### Test Enhancements:
* Updated `BusinessServiceImplTest` to use `findBusinessWithDigitalContactsById` and added a `BusinessTO` object to align with the updated mapping logic and entity structure (`src/test/java/com/prx/directory/api/v1/service/BusinessServiceImplTest.java`).…Instant` and streamlined `DigitalContactMapper` with MapStruct annotations.