### PR TITLE
Update Dockerfile to set default RESOURCE_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ LABEL version="0.0.1"
 LABEL description="Directory Backend API"
 LABEL mantainer="Luis Mata luis.antonio.mata@gmail.com"
 
-ARG RESOURCE_PATH=src/main/resources/
 ARG TARGET_FILE=target/
 ARG KEYSTORE_FILE=keystore
 ARG BACKBONE_ALIAS=backbone
@@ -16,6 +15,7 @@ ARG APP_CRT_ALIAS=directory-rest.tst
 ARG CNFS_CRT_NAME=prx-qa.config-server
 ARG APP_CRT_FILE_NAME=directory-rest
 ARG SUPABASE_CRT_FILE_NAME=prod-ca-2021
+ARG RESOURCE_PATH=src/main/resources/
 WORKDIR /usr/local/runme
 COPY ${TARGET_FILE}${JAR_FILE} ${JAR_FILE}
 COPY ${RESOURCE_PATH}${SUPABASE_CRT_FILE_NAME}.crt ${SUPABASE_CRT_FILE_NAME}.crt


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by moving the definition of the `RESOURCE_PATH` argument. The change ensures that `RESOURCE_PATH` is defined before it is used in the `COPY` command, which improves the build process reliability. No other functional changes are included.