### PR TITLE
Update Dockerfile to set default RESOURCE_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL version="0.0.1"
 LABEL description="Directory Backend API"
 LABEL mantainer="Luis Mata luis.antonio.mata@gmail.com"
 
+WORKDIR /usr/local/runme
 ARG TARGET_FILE=target/
 ARG KEYSTORE_FILE=keystore
 ARG BACKBONE_ALIAS=backbone
@@ -16,7 +17,6 @@ ARG CNFS_CRT_NAME=prx-qa.config-server
 ARG APP_CRT_FILE_NAME=directory-rest
 ARG SUPABASE_CRT_FILE_NAME=prod-ca-2021
 ARG RESOURCE_PATH=src/main/resources/
-WORKDIR /usr/local/runme
 COPY ${TARGET_FILE}${JAR_FILE} ${JAR_FILE}
 COPY ${RESOURCE_PATH}${SUPABASE_CRT_FILE_NAME}.crt ${SUPABASE_CRT_FILE_NAME}.crt
 COPY ${RESOURCE_PATH}${APP_CRT_FILE_NAME}.crt ${APP_CRT_FILE_NAME}.crt


### PR DESCRIPTION
This pull request introduces several improvements and optimizations to the backend API, focusing mainly on the Maven build configuration and campaign status counting logic. The most significant changes include replacing multiple database queries for campaign status counts with a single aggregate query, refactoring the Maven `pom.xml` for better build and test management, and updating the handling of MapStruct annotation processors. There are also minor adjustments to the Dockerfile and API/service method signatures for clarity and correctness.

### Campaign status counting optimization

* Added `CampaignStatusCounter` component to compute active, inactive, and expired campaign counts in a single aggregate query, reducing database round-trips and memory allocations. `CampaignServiceImpl` now uses this component for status counting. [[1]](diffhunk://#diff-7b32d2bb9172a1ea717652f06dc29fecf9491d8fb08c18aec3e03d6c3adc4e69R1-R77) [[2]](diffhunk://#diff-06d822b21af0ca0c3218ac9717ddb14941f24295159749ee0784a244864022bcL143-R151)
* Updated `CampaignServiceImpl` constructor to accept and use `CampaignStatusCounter` via dependency injection, simplifying unit testing and improving performance.

### Maven build and test configuration improvements

* Replaced the generic `argLine` property with a dedicated `jacoco.argLine` property to avoid conflicts with CI/global agent injection and updated Surefire and JaCoCo plugin configurations accordingly. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L41-R42) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L404-R416) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R623-R626)
* Moved `mapstruct-processor` dependency from the main dependencies section to the `maven-compiler-plugin`'s `annotationProcessorPaths`, ensuring proper annotation processing during build and test phases. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L158-R160) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R536-R574)
* Added JMH (Java Microbenchmark Harness) dependencies and a dedicated Maven profile (`benchmark`) for compiling and running microbenchmarks, facilitating performance testing. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R82-R83) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R294-R307) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R644-R674)

### API and service contract adjustments

* Updated `FavoriteApi` and `FavoriteService` method signatures to clarify favorite ID handling and improve validation, including use of `Objects.isNull` and explicit path variable mapping. [[1]](diffhunk://#diff-569d03f38ca9f4c339a80b6d4fbb8b2ce12d2c55aa07bc356d66eb246fb9954bL192-R199) [[2]](diffhunk://#diff-883fcf641ac64ec7f4d48075bb2813ee036e7b1834be25f4ef13216f31821e48L61-R63)
* Added `@Transactional(readOnly = true)` annotations to relevant service methods for improved transaction management and read-only semantics. [[1]](diffhunk://#diff-06d822b21af0ca0c3218ac9717ddb14941f24295159749ee0784a244864022bcR95) [[2]](diffhunk://#diff-c5e0f841af647153bb365630c2897d77ff111cbfa1344f3968a0ef4cc4afaaf7R95)

### Dockerfile and minor dependency changes

* Fixed the `RESOURCE_PATH` argument in the Dockerfile for correct resource copying. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R18)
* Minor import and dependency adjustments for completeness and clarity in service implementations. [[1]](diffhunk://#diff-c5e0f841af647153bb365630c2897d77ff111cbfa1344f3968a0ef4cc4afaaf7R6) [[2]](diffhunk://#diff-883fcf641ac64ec7f4d48075bb2813ee036e7b1834be25f4ef13216f31821e48R9-R10) [[3]](diffhunk://#diff-569d03f38ca9f4c339a80b6d4fbb8b2ce12d2c55aa07bc356d66eb246fb9954bR20)