### PR TITLE
Update Dockerfile to set default RESOURCE_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ LABEL version="0.0.1"
 LABEL description="Directory Backend API"
 LABEL mantainer="Luis Mata luis.antonio.mata@gmail.com"
 
-WORKDIR /usr/local/runme
 ARG TARGET_FILE=target/
 ARG KEYSTORE_FILE=keystore
 ARG BACKBONE_ALIAS=backbone
@@ -17,6 +16,7 @@ ARG CNFS_CRT_NAME=prx-qa.config-server
 ARG APP_CRT_FILE_NAME=directory-rest
 ARG SUPABASE_CRT_FILE_NAME=prod-ca-2021
 ARG RESOURCE_PATH=src/main/resources/
+WORKDIR /usr/local/runme
 COPY ${TARGET_FILE}${JAR_FILE} ${JAR_FILE}
 COPY ${RESOURCE_PATH}${SUPABASE_CRT_FILE_NAME}.crt ${SUPABASE_CRT_FILE_NAME}.crt
 COPY ${RESOURCE_PATH}${APP_CRT_FILE_NAME}.crt ${APP_CRT_FILE_NAME}.crt


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by moving the `WORKDIR /usr/local/runme` directive further down in the file. This change ensures that the working directory is set just before copying files, which can help avoid potential issues if earlier build steps depend on a different working directory.

- Dockerfile improvements:
  * Relocated the `WORKDIR /usr/local/runme` directive to after the environment variable declarations, just before file copy operations, to ensure correct context during copy steps. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R19)